### PR TITLE
Add a taxonomy for report result to simplify counting and querying.

### DIFF
--- a/parts/result-set-all.php
+++ b/parts/result-set-all.php
@@ -7,7 +7,6 @@ echo Display::get_display_css(); ?>
 	<thead>
 		<tr>
 			<th style="width:100px">Revision</th>
-			<th style="width:100px">Environments</th>
 			<th style="width:100px">Passed</th>
 			<th style="width:100px">Failed</th>
 			<th style="width:100px">➡️</th>
@@ -17,34 +16,9 @@ echo Display::get_display_css(); ?>
 		<?php
 		foreach ( $revisions as $revision ) :
 			$rev_id = (int) ltrim( $revision->post_name, 'r' );
-      $query_args   = array(
-        'posts_per_page' => $posts_per_page,
-        'post_type'      => 'result',
-        'post_parent'    => $revision->ID,
-        'orderby'        => 'post_title',
-        'order'          => 'ASC',
-      );
-      $report_query = new WP_Query( $query_args );
 
-      $environments = [];
-      $num_hosts = 0;
-      $num_passed = 0;
-      $num_failed = 0;
-
-      foreach ( $report_query->posts as $report ) {
-				$env = Display::get_display_environment_name($report->ID);
-
-				$environments[$env] ??= 0;
-				++$environments[$env];
-
-				$results = get_post_meta($report->ID, 'results', true);
-
-				if (0 === (int) $results['failures'] && 0 === (int) $results['errors']) {
-					++$num_passed;
-				} else {
-					++$num_failed;
-				}
-			}
+			$num_passed = ptr_count_test_results( $revision->ID );
+			$num_failed = ptr_count_test_results( $revision->ID, true );
 			?>
 			<tr>
 				<td>
@@ -54,9 +28,7 @@ echo Display::get_display_css(); ?>
             r<?php echo $rev_id; ?>
           </a>
         </td>
-        <td>
-          <?php echo count( $environments ); ?>
-        </td>
+
         <td>
             <span class="ptr-status-badge ptr-status-badge-passed">
 			        <?php echo $num_passed; ?>

--- a/parts/result-set-all.php
+++ b/parts/result-set-all.php
@@ -18,7 +18,7 @@ echo Display::get_display_css(); ?>
 			$rev_id = (int) ltrim( $revision->post_name, 'r' );
 
 			$num_passed = ptr_count_test_results( $revision->ID );
-			$num_failed = ptr_count_test_results( $revision->ID, true );
+			$num_failed = ptr_count_test_results( $revision->ID, 'failed' );
 			?>
 			<tr>
 				<td>

--- a/phpunit-test-reporter.php
+++ b/phpunit-test-reporter.php
@@ -97,12 +97,12 @@ function ptr_get_template_part( $template, $vars = array() ) {
 /**
  * Counts the number of failing or passing test reports for a revision.
  *
- * @param int  $revision_parent_id The current revision's post ID.
- * @param bool $failures           Whether to count failures. Default is false (count successful reports).
+ * @param int    $revision_parent_id The current revision's post ID.
+ * @param string $status             The status term slug to count.
  *
- * @return int The number of reports for the given revision that either passed or failed.
+ * @return int The number of reports for the given revision.
  */
-function ptr_count_test_results( $revision_parent_id, $failures = false ) {
+function ptr_count_test_results( $revision_parent_id, $status = 'passed' ) {
 	$report_query = new WP_Query(
 		array(
 			'post_type'      => 'result',
@@ -112,7 +112,7 @@ function ptr_count_test_results( $revision_parent_id, $failures = false ) {
 			'tax_query'      => array(
 				array(
 					'taxonomy'   => 'report-result',
-					'terms'      => $failures ? 'failed' : 'passed',
+					'terms'      => $status,
 					'field'      => 'slug',
 				),
 			)

--- a/phpunit-test-reporter.php
+++ b/phpunit-test-reporter.php
@@ -93,3 +93,35 @@ function ptr_get_template_part( $template, $vars = array() ) {
 	include $full_path;
 	return ob_get_clean();
 }
+
+/**
+ * Counts the number of failing or passing test reports for a revision.
+ *
+ * @param int  $revision_parent_id The current revision's post ID.
+ * @param bool $failures           Whether to count failures. Default is false (count successful reports).
+ *
+ * @return int The number of reports for the given revision that either passed or failed.
+ */
+function ptr_count_test_results( $revision_parent_id, $failures = false ) {
+	$report_query = new WP_Query(
+		array(
+			'post_type'      => 'result',
+			'post_parent'    => $revision_parent_id,
+			'fields'         => 'ids',
+			'posts_per_page' => 1,
+			'tax_query'      => array(
+				array(
+					'taxonomy'   => 'report-result',
+					'terms'      => $failures ? 'failed' : 'passed',
+					'field'      => 'slug',
+				),
+			)
+		)
+	);
+
+	if ( ! $report_query->have_posts() ) {
+		return 0;
+	}
+
+	return $report_query->found_posts;
+}

--- a/src/class-content-model.php
+++ b/src/class-content-model.php
@@ -78,6 +78,24 @@ class Content_Model {
 				'show_in_rest'               => true,
 			)
 		);
+
+		register_taxonomy(
+			'report-result',
+			array( 'result' ),
+			array(
+				'labels'       => array(
+					'name'          => __( 'Result Status', 'ptr' ),
+					'singular_name' => __( 'Result Status', 'ptr' ),
+				),
+				'hierarchical'               => false,
+				'public'                     => false,
+				'show_ui'                    => true,
+				'show_admin_column'          => true,
+				'show_in_nav_menus'          => false,
+				'show_tagcloud'              => false,
+				'show_in_rest'               => true,
+			)
+		);
 	}
 
 	/**

--- a/src/class-display.php
+++ b/src/class-display.php
@@ -151,7 +151,6 @@ class Display {
 			$output .= ptr_get_template_part(
 					'result-set-all',
 					array(
-							'posts_per_page' => 50,
 							'revisions' => $rev_query->posts,
 					)
 			);

--- a/src/class-restapi.php
+++ b/src/class-restapi.php
@@ -121,7 +121,8 @@ class RestAPI {
 			$php_version = $parts[0] . '.' . $parts[1];
 		}
 
-		$env_type = $env['label'] ?? '';;
+		$env_name = $env['env_name'] ?? '';;
+		$env_type = $env['type'] ?? '';;
 
 		$current_user = wp_get_current_user();
 
@@ -158,10 +159,6 @@ class RestAPI {
 			$post_id = $results[0]->ID;
 		} else {
 			$post_title = $current_user->user_login . ' - ' . $slug;
-
-			if ( $env_type ) {
-				$post_title .= '-' . $env_type;
-			}
 
 			if ( $php_version ) {
 				$post_title .= '-' . $php_version;

--- a/src/class-restapi.php
+++ b/src/class-restapi.php
@@ -193,6 +193,12 @@ class RestAPI {
 		update_post_meta( $post_id, 'env', $env );
 		update_post_meta( $post_id, 'results', $results );
 
+		if ( empty( $results['failures'] ) && empty( $results['errors'] ) ) {
+			wp_set_object_terms( $post_id, 'Failed', 'report-result' );
+		} else {
+			wp_set_object_terms( $post_id, 'Passed', 'report-result' );
+		}
+
 		self::maybe_send_email_notifications( $parent_id );
 
 		// Create the response object.

--- a/src/class-restapi.php
+++ b/src/class-restapi.php
@@ -121,8 +121,7 @@ class RestAPI {
 			$php_version = $parts[0] . '.' . $parts[1];
 		}
 
-		$env_name = $env['env_name'] ?? '';;
-		$env_type = $env['type'] ?? '';;
+		$env_type = $env['label'] ?? '';;
 
 		$current_user = wp_get_current_user();
 
@@ -159,6 +158,10 @@ class RestAPI {
 			$post_id = $results[0]->ID;
 		} else {
 			$post_title = $current_user->user_login . ' - ' . $slug;
+
+			if ( $env_type ) {
+				$post_title .= '-' . $env_type;
+			}
 
 			if ( $php_version ) {
 				$post_title .= '-' . $php_version;


### PR DESCRIPTION
This simplifies the logic around counting report outcomes and removes the displaying of environments counts.