### PR TITLE
Attempt to track reports by a hash

### DIFF
--- a/src/class-restapi.php
+++ b/src/class-restapi.php
@@ -200,20 +200,19 @@ class RestAPI {
 			// Store the results.
 			$post_id = wp_insert_post( $args, true );
 
+			if ( is_wp_error( $post_id ) ) {
+				return $post_id;
+			}
+
 			update_post_meta( $post_id, 'report_hash', $report_hash );
+			update_post_meta( $post_id, 'env', $env );
+
+			wp_set_object_terms( $post_id, array( $php_version ), 'php-version' );
+			wp_set_object_terms( $post_id, array( $env_type ), 'environment-type' );
 		}
 
-		if ( is_wp_error( $post_id ) ) {
-			return $post_id;
-		}
-
-		wp_set_object_terms( $post_id, array( $php_version ), 'php-version' );
-		wp_set_object_terms( $post_id, array( $env_type ), 'environment-type' );
-
-		$env     = isset( $parameters['env'] ) ? json_decode( $parameters['env'], true ) : array();
 		$results = isset( $parameters['results'] ) ? json_decode( $parameters['results'], true ) : array();
 
-		update_post_meta( $post_id, 'env', $env );
 		update_post_meta( $post_id, 'results', $results );
 
 		self::maybe_send_email_notifications( $parent_id );

--- a/src/class-restapi.php
+++ b/src/class-restapi.php
@@ -199,6 +199,8 @@ class RestAPI {
 
 			// Store the results.
 			$post_id = wp_insert_post( $args, true );
+
+			update_post_meta( $post_id, 'report_hash', $report_hash );
 		}
 
 		if ( is_wp_error( $post_id ) ) {

--- a/src/class-restapi.php
+++ b/src/class-restapi.php
@@ -115,6 +115,21 @@ class RestAPI {
 
 		$env = isset( $parameters['env'] ) ? json_decode( $parameters['env'], true ) : array();
 
+		/*
+		 * Create a unique hash for this report based on the details provided.
+		 *
+		 * This helps avoid overwriting the wrong report when testers submit multiple reports
+		 * using the same environment type or PHP version.
+		 */
+		$report_hash = md5(
+			wp_json_encode(
+				array(
+					'env' => $env,
+					'revision' => $parameters['commit'],
+				)
+			)
+		);
+
 		$php_version = '';
 		if ( isset( $env['php_version'] ) ) {
 			$parts = explode( '.', $env['php_version'] );
@@ -152,6 +167,12 @@ class RestAPI {
 			'numberposts' => 1,
 			'author'      => $current_user->ID,
 			'tax_query'   => $tax_query,
+			'meta_query'  => array(
+				array(
+					'key'   => 'report_hash',
+					'value' => $report_hash,
+				),
+			),
 		) );
 
 		if ( $results ) {


### PR DESCRIPTION
This attempts to track reports using a hash of the environment details provided.

This will avoid unintentionally overwriting reports where the same PHP version or environment type/name/thing is used.

An example of this would be a hosting provider that tests their cloud hosting and shared hosting with supported PHP versions and different MySQL versions. Currently, the MySQL reports would overwrite each other. 